### PR TITLE
Fix account loading on order page

### DIFF
--- a/src/pages/OrderPage/useOrderTicket.ts
+++ b/src/pages/OrderPage/useOrderTicket.ts
@@ -57,6 +57,5 @@ export const useOrderTicket = () => {
       hasSwimmers,
       hasTicketAmount,
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [hasAccount, history, location, tickets])
 }


### PR DESCRIPTION
Problem - if you open the page on /order (or refresh) as a logged in user, it takes a moment before account data is loaded in. Because the useOrderTicket useMemo had no dependencies, it remembers only the initial input in which the user data is not available and assumes we are logged out. This way it updates the params when the user updates.

Kept in the rest of the dependencies as recommended by eslint. None of them looks "dangerous" (shouldn't cause unwanted refreshes), but let me know if you disagree.

This way the refresh on order briefly flashes the version of the form for logged out user, could be solved by listening on user data loading, but imo good enough.