### PR TITLE
access_token parsed from query

### DIFF
--- a/src/helpers/cityAccountToken.ts
+++ b/src/helpers/cityAccountToken.ts
@@ -80,6 +80,14 @@ export const getAccessTokenFromIFrame = async () => {
     // all as it should be, user is not logged in
     return null
   }
-  logger.warn('None or invalid token received from iframe', postMessageError, accessToken)
-  return null
+  if (postMessageError) {
+    logger.error('Error when waiting for token from iframe', postMessageError, accessToken)
+    throw postMessageError
+  } else {
+    logger.warn(
+      'None or invalid token received from iframe for possibly authorized user - returning null',
+      token,
+    )
+    return null
+  }
 }


### PR DESCRIPTION
There are users who are succesfully logged in in city-account but see themselves logged out on kupaliska. We also see some logs of iframe not loading correctly (internet connection ? old browser ? blocked by extensions ?) - this should help these users.

It;s not ideal to pass tokens in urls, we may replace this with something cookie based in the future.