### PR TITLE
Add liveness and readiness probes to app deployment

### DIFF
--- a/kubernetes/base/deployment.yml
+++ b/kubernetes/base/deployment.yml
@@ -35,6 +35,20 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
           envFrom:
             - configMapRef:
                 name: env


### PR DESCRIPTION
## What

Adds `readinessProbe` and `livenessProbe` to the app container in `kubernetes/base/deployment.yml` — Kubernetes-side change only ("option A"), no app/nginx changes.

## Details

- Both probes httpGet `/` on named port `http` (nginx serves index.html with 200, so no `/health` endpoint needed)
- Timing values mirror the backend agreement: readiness 5s/5s/6 fails, liveness 30s/15s/3 fails
- `kube-probe` user-agent doesn't match the bot regex in nginx.conf, so probes won't trigger the rendertron rewrite
- Rendertron deployment intentionally untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)