### PR TITLE
321 errors order page non physical entity

### DIFF
--- a/public/locales/sk/translation.json
+++ b/public/locales/sk/translation.json
@@ -168,6 +168,7 @@
     "max-ticket-purchase-limit-exceeded": "Presiahnutý maximálny počet lístkov na objednávke",
     "select-people-reminder-seasonal": "Vyberte prosím všetky osoby pre ktoré chcete kúpiť permanentky:",
     "select-people-reminder-entries": "Vyberte prosím všetky osoby pre ktoré chcete kúpiť lístky:",
+    "min-one-person": "Vyberte aspoň jednu osobu, pre ktorú chcete kúpiť permanentku.",
     "pay": "Zaplatiť",
     "pay-with-google-pay": "Google Pay",
     "pay-with-apple-pay": "Apple Pay",

--- a/src/components/OrderPage/OrderPageSwimmersList.tsx
+++ b/src/components/OrderPage/OrderPageSwimmersList.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import cx from 'classnames'
 import { AssociatedSwimmer } from '../../store/associatedSwimmers/api'
 import { Button as AriaButton, Checkbox } from 'react-aria-components'
@@ -51,7 +52,7 @@ const OrderPageSwimmersList = ({
   return (
     <div className="gap-3 flex flex-col pt-3">
       {swimmers.map((swimmer) => (
-        <>
+        <Fragment key={swimmer.id}>
           <Checkbox
             className={cx('px-4 py-3 gap-4 flex items-center rounded-lg cursor-pointer', {
               'bg-white': !isDisabledCheckbox(swimmer),
@@ -81,7 +82,7 @@ const OrderPageSwimmersList = ({
           </Checkbox>
           {/* TODO errors everywhere, refactor */}
           {isDisabledCheckbox(swimmer) && t('common.physical-person-only')}
-        </>
+        </Fragment>
       ))}
       <AriaButton
         onPress={() => onAddSwimmer()}

--- a/src/components/OrderPage/OrderPageSwimmersList.tsx
+++ b/src/components/OrderPage/OrderPageSwimmersList.tsx
@@ -79,6 +79,7 @@ const OrderPageSwimmersList = ({
             </div>
             <div className="react-aria-checkbox" />
           </Checkbox>
+          {/* TODO errors everywhere, refactor */}
           {isDisabledCheckbox(swimmer) && t('common.physical-person-only')}
         </>
       ))}

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, CheckboxField, Icon, InputField, Tooltip } from '../../components'
 import { Button as AriaButton } from 'react-aria-components'
 import { AssociatedSwimmer, fetchAssociatedSwimmers } from '../../store/associatedSwimmers/api'
@@ -756,26 +756,29 @@ const OrderPage = () => {
     control,
   })
 
-  const getRequestsFromFormData = () =>
-    orderFormToRequests({
-      ...getValues(),
-      ticketTypesData: getValues().ticketTypesData.map((ticketTypeData) => {
-        const { requireEmail, hasOptionalFields, hasSwimmers, hasTicketAmount } =
-          ticketTypesWithAdditionalProperties.find(
-            (ticketType) => ticketType.ticketType.id === ticketTypeData.ticketType.id,
-          )!
-        return {
-          ...ticketTypeData,
-          requireEmail,
-          hasOptionalFields,
-          hasSwimmers,
-          hasTicketAmount,
-        }
+  const getRequestsFromFormData = useCallback(
+    () =>
+      orderFormToRequests({
+        ...getValues(),
+        ticketTypesData: getValues().ticketTypesData.map((ticketTypeData) => {
+          const { requireEmail, hasOptionalFields, hasSwimmers, hasTicketAmount } =
+            ticketTypesWithAdditionalProperties.find(
+              (ticketType) => ticketType.ticketType.id === ticketTypeData.ticketType.id,
+            )!
+          return {
+            ...ticketTypeData,
+            requireEmail,
+            hasOptionalFields,
+            hasSwimmers,
+            hasTicketAmount,
+          }
+        }),
       }),
-    })
+    [],
+  )
 
   const priceQuery = useQuery(
-    'orderPrice',
+    ['orderPrice', ticketTypesData],
     ({ signal }) => {
       const { getPriceRequest } = getRequestsFromFormData()
 
@@ -800,7 +803,7 @@ const OrderPage = () => {
       queryClient.cancelQueries('orderPrice')
       queryClient.refetchQueries('orderPrice')
     }
-  }, [watchPriceChange, account])
+  }, [watchPriceChange, account, getRequestsFromFormData])
 
   useTimeout(() => {
     if (!isClient || captchaWarning === 'hide') return

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -698,6 +698,7 @@ const OrderPage = () => {
   const { t } = useTranslation()
   const isClient = useIsClient()
   const currencyFromCentsFormatter = useCurrencyFromCentsFormatter()
+  const { data: account } = useAccount()
 
   const {
     register,
@@ -788,6 +789,7 @@ const OrderPage = () => {
       onError: (err) => {
         dispatchErrorToastForHttpRequest(err as AxiosError<ErrorWithMessages>)
       },
+      enabled: getRequestsFromFormData().getPriceRequest.tickets.length > 0,
       retry: false,
     },
   )
@@ -795,11 +797,13 @@ const OrderPage = () => {
   const queryClient = useQueryClient()
 
   useEffect(() => {
-    // If the price should change, cancel current queries and fetch a new price.
-    queryClient.cancelQueries('orderPrice')
-    queryClient.refetchQueries('orderPrice')
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [watchPriceChange])
+    // same as enabled condition of price query
+    if (getRequestsFromFormData().getPriceRequest.tickets.length > 0) {
+      // If the price should change, cancel current queries and fetch a new price.
+      queryClient.cancelQueries('orderPrice')
+      queryClient.refetchQueries('orderPrice')
+    }
+  }, [watchPriceChange, account])
 
   useTimeout(() => {
     if (!isClient || captchaWarning === 'hide') return

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -161,21 +161,23 @@ const OrderPagePeopleList = ({
 
   /* Merges the list of associated swimmers with the logged-in user. */
   const mergedSwimmers = useMemo(() => {
-    return (
-      associatedSwimmersQuery.data &&
-      userQuery.data && [
-        {
-          id: null,
-          age: userQuery.data.data.age,
-          zip: userQuery.data.data.zip,
-          image: userQuery.data.data.image,
-          firstname: account?.given_name as string,
-          lastname: account?.family_name as string,
-          isPhysicalEntity: account?.['custom:account_type'] === AccountType.FO,
-        },
-        ...associatedSwimmersQuery.data.data.associatedSwimmers,
-      ]
-    )
+    const swimmersWithOwner = []
+    if (userQuery.data && account?.['custom:account_type'] === AccountType.FO) {
+      swimmersWithOwner.push({
+        id: null,
+        age: userQuery.data.data.age,
+        zip: userQuery.data.data.zip,
+        image: userQuery.data.data.image,
+        firstname: account?.given_name as string,
+        lastname: account?.family_name as string,
+        isPhysicalEntity: account?.['custom:account_type'] === AccountType.FO,
+      })
+    }
+    if (associatedSwimmersQuery.data) {
+      swimmersWithOwner.push(...associatedSwimmersQuery.data.data.associatedSwimmers)
+    }
+
+    return swimmersWithOwner
   }, [
     account?.family_name,
     account?.given_name,
@@ -295,13 +297,6 @@ const OrderPagePeopleList = ({
               Doplniť povinné údaje
             </AriaButton>
           </div>
-        </div>
-      )}
-      {/* TODO errors everywhere, refactor */}
-      {account?.['custom:account_type'] !== AccountType.FO && (
-        <div className="flex py-4 px-5 bg-[#FCF2E6] rounded-lg gap-x-3 my-6">
-          <Icon name="warning" className="no-fill text-white"></Icon>
-          <div>{t('common.physical-person-only')}</div>
         </div>
       )}
       {ticketTypesData.map(
@@ -1025,6 +1020,13 @@ const OrderPage = () => {
                     </div>
                   </div>
                 )}
+                {ticketTypesData.some((ticketTypeData) => ticketTypeData.ticketType.nameRequired) &&
+                  getRequestsFromFormData().getPriceRequest.tickets.length < 1 && (
+                    <div className="flex py-4 px-5 bg-[#FCF2E6] rounded-lg gap-x-3 my-6">
+                      <Icon name="warning" className="no-fill text-[#E07B04]"></Icon>
+                      <div>{t('buy-page.min-one-person')}</div>
+                    </div>
+                  )}
                 <OrderPagePeopleList
                   watch={watch}
                   setValue={setValue}

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -1011,6 +1011,8 @@ const OrderPage = () => {
                     <Icon name="warning" className="no-fill text-[#E07B04]"></Icon>
                     <div>
                       {getErrorMessagesFromHttpRequest(
+                        // TODO check if we show correct errors in all cases
+                        // (zod schema error - probably not, joi schema error, manually thrown error)
                         priceQuery.error as AxiosError<ErrorWithMessages>,
                       )}
                     </div>

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -786,9 +786,7 @@ const OrderPage = () => {
         // TODO errors everywhere, refactor
         dispatchErrorToastForHttpRequest(err as AxiosError<ErrorWithMessages>)
       },
-      enabled:
-        account?.['custom:account_type'] === AccountType.FO &&
-        getRequestsFromFormData().getPriceRequest.tickets.length > 0,
+      enabled: getRequestsFromFormData().getPriceRequest.tickets.length > 0,
       retry: false,
     },
   )
@@ -797,10 +795,7 @@ const OrderPage = () => {
 
   useEffect(() => {
     // same as enabled condition of price query
-    if (
-      account?.['custom:account_type'] === AccountType.FO &&
-      getRequestsFromFormData().getPriceRequest.tickets.length > 0
-    ) {
+    if (getRequestsFromFormData().getPriceRequest.tickets.length > 0) {
       // If the price should change, cancel current queries and fetch a new price.
       queryClient.cancelQueries('orderPrice')
       queryClient.refetchQueries('orderPrice')

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -298,7 +298,7 @@ const OrderPagePeopleList = ({
         </div>
       )}
       {/* TODO errors everywhere, refactor */}
-      {account?.['custom:account_type'] && account?.['custom:account_type'] !== AccountType.FO && (
+      {account?.['custom:account_type'] !== AccountType.FO && (
         <div className="flex py-4 px-5 bg-[#FCF2E6] rounded-lg gap-x-3 my-6">
           <Icon name="warning" className="no-fill text-white"></Icon>
           <div>{t('common.physical-person-only')}</div>

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -282,7 +282,7 @@ const OrderPagePeopleList = ({
           }}
         ></AssociatedSwimmerEditAddModal>
       )}
-
+      {/* TODO errors everywhere, refactor */}
       {shouldDisplayMissingInformationWarning && (
         <div className="flex py-4 px-5 bg-error rounded-lg gap-x-3 my-6 text-white">
           <Icon name="warning" className="no-fill text-white"></Icon>
@@ -297,6 +297,7 @@ const OrderPagePeopleList = ({
           </div>
         </div>
       )}
+      {/* TODO errors everywhere, refactor */}
       {account?.['custom:account_type'] && account?.['custom:account_type'] !== AccountType.FO && (
         <div className="flex py-4 px-5 bg-[#FCF2E6] rounded-lg gap-x-3 my-6">
           <Icon name="warning" className="no-fill text-white"></Icon>
@@ -787,6 +788,7 @@ const OrderPage = () => {
     },
     {
       onError: (err) => {
+        // TODO errors everywhere, refactor
         dispatchErrorToastForHttpRequest(err as AxiosError<ErrorWithMessages>)
       },
       enabled:
@@ -1012,6 +1014,7 @@ const OrderPage = () => {
                     />
                   )}
                 </div>
+                {/* TODO errors everywhere, refactor */}
                 {priceQuery.error && (
                   <div className="flex py-4 px-5 bg-[#FCF2E6] rounded-lg gap-x-3 my-6">
                     <Icon name="warning" className="no-fill text-[#E07B04]"></Icon>

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -789,7 +789,9 @@ const OrderPage = () => {
       onError: (err) => {
         dispatchErrorToastForHttpRequest(err as AxiosError<ErrorWithMessages>)
       },
-      enabled: getRequestsFromFormData().getPriceRequest.tickets.length > 0,
+      enabled:
+        account?.['custom:account_type'] === AccountType.FO &&
+        getRequestsFromFormData().getPriceRequest.tickets.length > 0,
       retry: false,
     },
   )
@@ -798,7 +800,10 @@ const OrderPage = () => {
 
   useEffect(() => {
     // same as enabled condition of price query
-    if (getRequestsFromFormData().getPriceRequest.tickets.length > 0) {
+    if (
+      account?.['custom:account_type'] === AccountType.FO &&
+      getRequestsFromFormData().getPriceRequest.tickets.length > 0
+    ) {
       // If the price should change, cancel current queries and fetch a new price.
       queryClient.cancelQueries('orderPrice')
       queryClient.refetchQueries('orderPrice')

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -714,7 +714,7 @@ const OrderPage = () => {
     defaultValues: {
       ticketTypesData: ticketTypesWithAdditionalProperties.map((ticketType) => ({
         ticketType: ticketType.ticketType,
-        ...(ticketType.hasSwimmers ? { selectedSwimmerIds: [null] } : {}),
+        ...(ticketType.hasSwimmers ? { selectedSwimmerIds: [] } : {}),
         ...(ticketType.hasTicketAmount
           ? {
               ticketAmount:

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -1008,7 +1008,7 @@ const OrderPage = () => {
                     <Icon name="warning" className="no-fill text-[#E07B04]"></Icon>
                     <div>
                       {getErrorMessagesFromHttpRequest(
-                        priceQuery.error as AxiosError<ErrorWithMessages, any>,
+                        priceQuery.error as AxiosError<ErrorWithMessages>,
                       )}
                     </div>
                   </div>

--- a/src/pages/OrderPage/OrderPage.tsx
+++ b/src/pages/OrderPage/OrderPage.tsx
@@ -774,7 +774,7 @@ const OrderPage = () => {
           }
         }),
       }),
-    [],
+    [getValues, ticketTypesWithAdditionalProperties],
   )
 
   const priceQuery = useQuery(
@@ -800,10 +800,10 @@ const OrderPage = () => {
     // same as enabled condition of price query
     if (getRequestsFromFormData().getPriceRequest.tickets.length > 0) {
       // If the price should change, cancel current queries and fetch a new price.
-      queryClient.cancelQueries('orderPrice')
-      queryClient.refetchQueries('orderPrice')
+      queryClient.cancelQueries([['orderPrice', ticketTypesData]])
+      queryClient.refetchQueries([['orderPrice', ticketTypesData]])
     }
-  }, [watchPriceChange, account, getRequestsFromFormData])
+  }, [watchPriceChange, account, ticketTypesData])
 
   useTimeout(() => {
     if (!isClient || captchaWarning === 'hide') return
@@ -882,24 +882,22 @@ const OrderPage = () => {
         text = t('buy-page.pay-with-google-pay')
         break
       case PaymentMethod.CARD:
-        text =
-          priceQuery.isSuccess && !priceQuery.isFetching
-            ? t('buy-page.pay-with-price', {
-                price: currencyFromCentsFormatter.format(
-                  priceQuery.data.data.data.pricing.orderPriceWithVat,
-                ),
-              })
-            : t('buy-page.pay')
+        text = priceQuery.data?.data.data.pricing.orderPriceWithVat
+          ? t('buy-page.pay-with-price', {
+              price: currencyFromCentsFormatter.format(
+                priceQuery.data.data.data.pricing.orderPriceWithVat,
+              ),
+            })
+          : t('buy-page.pay')
         break
       default:
-        text =
-          priceQuery.isSuccess && !priceQuery.isFetching
-            ? t('buy-page.pay-with-price', {
-                price: currencyFromCentsFormatter.format(
-                  priceQuery.data.data.data.pricing.orderPriceWithVat,
-                ),
-              })
-            : t('buy-page.pay')
+        text = priceQuery.data?.data.data.pricing.orderPriceWithVat
+          ? t('buy-page.pay-with-price', {
+              price: currencyFromCentsFormatter.format(
+                priceQuery.data.data.data.pricing.orderPriceWithVat,
+              ),
+            })
+          : t('buy-page.pay')
         break
     }
 

--- a/src/pages/OrderPage/formDataToRequests.ts
+++ b/src/pages/OrderPage/formDataToRequests.ts
@@ -2,6 +2,26 @@ import { times } from 'lodash'
 import { TicketType } from 'models/order'
 import { OrderFormData } from './OrderPage'
 
+interface RequestTicket {
+  ticketTypeId?: string
+  personId?: string | null
+  age?: number | null
+  zip?: string | null
+}
+
+export interface GetPriceRequest {
+  tickets: RequestTicket[]
+  discountsPercent?: { ticketTypeId: string; discountPercent: number }[]
+}
+
+export interface OrderRequestBody {
+  tickets: RequestTicket[]
+  discountCodes?: string[]
+  email?: string
+  agreement: boolean
+  token?: string
+}
+
 export interface OrderFormTicketTypeData {
   ticketType?: TicketType
   ticketAmount?: number
@@ -16,8 +36,8 @@ export function orderFormToRequests(
 ) {
   const { discountCode, ticketTypesData, age, zip, email, agreement, recaptchaToken } = formData
 
-  let getPriceRequest = {} as any
-  let orderRequest = {} as any
+  let getPriceRequest: GetPriceRequest = { tickets: [] }
+  let orderRequest: OrderRequestBody = { tickets: [], agreement: false }
 
   if (discountCode) {
     // TODO implement multiple discount codes, BE already supports it,


### PR DESCRIPTION
- Non-physical entity (non-FO) account handling — owner of a non-FO account is no longer included in the swimmers list
- getPrice request gating — request is disabled when the tickets array is empty, preventing a failing request on initial page load; stale errors are now reset via queryClient.resetQueries when tickets drop to zero
- OrderPageSwimmersList key fix — replaced <> fragments with <Fragment key={swimmer.id}> to fix missing React key warning
- formDataToRequests types — added explicit GetPriceRequest and OrderRequestBody interfaces; replaced untyped {} locals with typed, properly initialized objects
- "Min one person" validation message — added new SK translation buy-page.min-one-person shown when a name-required ticket type has no swimmers selected
- Default swimmer pre-selection removed — initial selectedSwimmerIds defaults to [] instead of [null] (owner no longer pre-selected)

Closes https://github.com/bratislava/kupaliska-starz-fe/issues/321 partialy