### PR TITLE
254 city account hook fixes

### DIFF
--- a/src/hooks/useCityAccount.tsx
+++ b/src/hooks/useCityAccount.tsx
@@ -63,7 +63,7 @@ export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNo
     [setAccessTokenState],
   )
 
-  const validateTokenInLocalStorage = useCallback(() => {
+  const removeInvalidAccessTokenInLocalStorage = useCallback(() => {
     if (!checkTokenValid(accessToken)) {
       setAccessTokenState({ accessToken: null })
       return null
@@ -74,11 +74,11 @@ export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNo
 
   useEffect(() => {
     // prevent stale token in storage, in case iframe refresh does not work
-    window.addEventListener('focus', validateTokenInLocalStorage)
+    window.addEventListener('focus', removeInvalidAccessTokenInLocalStorage)
     return () => {
-      window.removeEventListener('focus', validateTokenInLocalStorage)
+      window.removeEventListener('focus', removeInvalidAccessTokenInLocalStorage)
     }
-  }, [validateTokenInLocalStorage])
+  }, [removeInvalidAccessTokenInLocalStorage])
 
   const getTokenFromUrl = useCallback(() => {
     try {
@@ -102,7 +102,7 @@ export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNo
 
   useEffectOnce(() => {
     setInitializationState('initializing')
-    validateTokenInLocalStorage()
+    removeInvalidAccessTokenInLocalStorage()
     // try getting token from iframe - this tends to fail randomly
     refreshAccessToken(true)
       .then((token) => {

--- a/src/hooks/useCityAccount.tsx
+++ b/src/hooks/useCityAccount.tsx
@@ -18,8 +18,8 @@ interface CityAccountAccessTokenState {
 
 export const ACCESS_TOKEN_STORAGE_KEY = 'cognitoAccessToken'
 
-const CityAccountAccessTokenContext = createContext<CityAccountAccessTokenState>(
-  {} as CityAccountAccessTokenState,
+const CityAccountAccessTokenContext = createContext<CityAccountAccessTokenState | undefined>(
+  undefined,
 )
 
 export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNode }) => {

--- a/src/hooks/useCityAccount.tsx
+++ b/src/hooks/useCityAccount.tsx
@@ -66,9 +66,6 @@ export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNo
   const removeInvalidAccessTokenInLocalStorage = useCallback(() => {
     if (!checkTokenValid(accessToken)) {
       setAccessTokenState({ accessToken: null })
-      return null
-    } else {
-      return accessToken
     }
   }, [accessToken, setAccessTokenState])
 
@@ -110,6 +107,7 @@ export const CityAccountAccessTokenProvider = ({ children }: { children: ReactNo
         getTokenFromUrl()
         if (token) {
           // iframe works, refresh from it on refocus
+          // TODO possible memory leak because we send new function to addEventListener, but it is called only when hook is first called
           window.addEventListener('focus', () => refreshAccessToken(false))
         }
       })


### PR DESCRIPTION
- add default undefined as default value in `CityAccountAccessTokenContext`
- rename function from `validateTokenInLocalStorage` to `removeInvalidAccessTokenInLocalStorage` to better corresponds with what it does
- remove return from  `removeInvalidAccessTokenInLocalStorage` as it isn't use anywhere

Closes https://github.com/bratislava/kupaliska-starz-be/issues/254